### PR TITLE
fix: セッション認証→トークン認証に切り替え

### DIFF
--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -2,45 +2,65 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
-use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Validation\ValidationException;
 
 class AuthController extends Controller
 {
     // ログイン
-    public function login(Request $request)
+    public function login(Request $request): JsonResponse
     {
-        // 1. バリデーション
         $validated = $request->validate([
             'email' => 'required|email',
             'password' => 'required',
         ]);
 
-        // 2. 認証
-        if (Auth::attempt($validated)) {
-            // 3. 認証成功：セッション再生成
-            $request->session()->regenerate();
+        $user = User::where('email', $validated['email'])->first();
 
-            return response()->json(Auth::user());
+        if (! $user || ! Hash::check($validated['password'], $user->password)) {
+            throw ValidationException::withMessages([
+                'email' => ['認証情報が正しくありません。'],
+            ]);
         }
 
-        // 4. 認証失敗
-        return response()->json(['message' => 'ログイン失敗'], 401);
+        // 既存トークン削除（1デバイス1トークン）
+        $user->tokens()->delete();
+
+        // トークン発行
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        return response()->json([
+            'user' => [
+                'id' => $user->id,
+                'name' => $user->name,
+                'email' => $user->email,
+                'role' => $user->role,
+            ],
+            'token' => $token,
+        ]);
     }
 
     // ログアウト
-    public function logout(Request $request)
+    public function logout(Request $request): JsonResponse
     {
-        Auth::guard('web')->logout();           // 認証解除
-        $request->session()->invalidate();       // セッション破棄
-        $request->session()->regenerateToken();  // セキュリティ用トークン再生成
+        $request->user()->currentAccessToken()->delete();
 
         return response()->json(['message' => 'ログアウトしました']);
     }
 
-    public function me(Request $request)
+    // 現在のユーザー情報
+    public function me(Request $request): JsonResponse
     {
-        return response()->json(Auth::user());
+        $user = $request->user();
 
+        return response()->json([
+            'id' => $user->id,
+            'name' => $user->name,
+            'email' => $user->email,
+            'role' => $user->role,
+        ]);
     }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -3,15 +3,16 @@
 namespace App\Models;
 
 // use Illuminate\Contracts\Auth\MustVerifyEmail;
+use Illuminate\Database\Eloquent\Concerns\HasUuids;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
-use Illuminate\Database\Eloquent\Concerns\HasUuids;
+use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable
 {
     /** @use HasFactory<\Database\Factories\UserFactory> */
-    use HasFactory, HasUuids, Notifiable;
+    use HasApiTokens, HasFactory, HasUuids, Notifiable;
 
     /**
      * The attributes that are mass assignable.
@@ -22,7 +23,7 @@ class User extends Authenticatable
         'name',
         'email',
         'password',
-        'role'
+        'role',
     ];
 
     /**

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -12,10 +12,9 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware) {
-     $middleware->statefulApi();
-     $middleware->alias([
-        'admin' => \App\Http\Middleware\AdminMiddleware::class,
-    ]);
+        $middleware->alias([
+            'admin' => \App\Http\Middleware\AdminMiddleware::class,
+        ]);
     })
     ->withExceptions(function (Exceptions $exceptions) {
         //

--- a/database/migrations/2026_02_10_085635_create_personal_access_tokens_table.php
+++ b/database/migrations/2026_02_10_085635_create_personal_access_tokens_table.php
@@ -13,7 +13,7 @@ return new class extends Migration
     {
         Schema::create('personal_access_tokens', function (Blueprint $table) {
             $table->id();
-            $table->morphs('tokenable');
+            $table->uuidMorphs('tokenable');
             $table->text('name');
             $table->string('token', 64)->unique();
             $table->text('abilities')->nullable();


### PR DESCRIPTION
## 概要
Sanctumのセッション認証 → トークン認証に切り替え

## 変更内容
- HasApiTokens追加・AuthController修正
- statefulApi()削除
- personal_access_tokens tokenable_idをUUID対応に変更

## 関連Issue
closes #18