### PR TITLE
fix: BanCellControllerのモデル参照バグ修正

### DIFF
--- a/app/Http/Controllers/BanCellController.php
+++ b/app/Http/Controllers/BanCellController.php
@@ -2,33 +2,36 @@
 
 namespace App\Http\Controllers;
 
+use App\Models\BanCell;
 use Illuminate\Http\Request;
-use App\Models\DamageCell;
 
 class BanCellController extends Controller
 {
     public function index(Request $request)
-{
-    $cells = BanCell::where('hole_number', $request->hole_number)->get();
-    return response()->json($cells);
-}
+    {
+        $cells = BanCell::where('hole_number', $request->hole_number)->get();
 
-public function store(Request $request)
-{
-    $validated = $request->validate([
-        'hole_number' => 'required|integer|between:1,18',
-        'x' => 'required|integer',
-        'y' => 'required|integer',
-    ]);
+        return response()->json($cells);
+    }
 
-    $cell = DamageCell::create($validated);
-    return response()->json($cell, 201);
-}
+    public function store(Request $request)
+    {
+        $validated = $request->validate([
+            'hole_number' => 'required|integer|between:1,18',
+            'x' => 'required|integer',
+            'y' => 'required|integer',
+        ]);
 
-public function destroy(string $id)
-{
-    $cell = DamageCell::findOrFail($id);
-    $cell->delete();
-    return response()->json(['message' => '削除しました']);
-}
+        $cell = BanCell::create($validated);
+
+        return response()->json($cell, 201);
+    }
+
+    public function destroy(string $id)
+    {
+        $cell = BanCell::findOrFail($id);
+        $cell->delete();
+
+        return response()->json(['message' => '削除しました']);
+    }
 }


### PR DESCRIPTION
## 概要
BanCellControllerがDamageCellモデルを参照していたバグを修正

## 実施した内容
- use文をDamageCell→BanCellに修正
- store・destroyのモデル参照をBanCellに修正

## 関連issue
#24