### PR TITLE
feat: セッションフロー（権限変更+遷移バリデーション）

### DIFF
--- a/app/Http/Controllers/PinSessionController.php
+++ b/app/Http/Controllers/PinSessionController.php
@@ -9,6 +9,34 @@ use Illuminate\Http\Request;
 
 class PinSessionController extends Controller
 {
+    /**
+     * ステータス遷移ルール
+     * key: 遷移先, value: 許可される遷移元
+     */
+    private const STATUS_TRANSITIONS = [
+        'checked' => 'draft',
+        'published' => 'checked',
+        'confirmed' => 'published',
+        'approved' => 'confirmed',
+        'sent' => 'approved',
+    ];
+
+    /**
+     * ステータス遷移バリデーション
+     */
+    private function validateTransition(PinSession $session, string $nextStatus): ?JsonResponse
+    {
+        $expectedCurrent = self::STATUS_TRANSITIONS[$nextStatus] ?? null;
+
+        if ($expectedCurrent && $session->status !== $expectedCurrent) {
+            return response()->json([
+                'message' => "ステータスを {$session->status} から {$nextStatus} に変更できません（現在のステータスが {$expectedCurrent} である必要があります）",
+            ], 422);
+        }
+
+        return null;
+    }
+
     public function index(Request $request): JsonResponse
     {
         $query = PinSession::query();
@@ -89,6 +117,10 @@ class PinSessionController extends Controller
     {
         $session = PinSession::findOrFail($id);
 
+        if ($error = $this->validateTransition($session, 'checked')) {
+            return $error;
+        }
+
         $session->update([
             'status' => 'checked',
         ]);
@@ -99,6 +131,10 @@ class PinSessionController extends Controller
     public function publish(string $id): JsonResponse
     {
         $session = PinSession::findOrFail($id);
+
+        if ($error = $this->validateTransition($session, 'published')) {
+            return $error;
+        }
 
         $session->update([
             'status' => 'published',
@@ -111,6 +147,11 @@ class PinSessionController extends Controller
     public function confirm(Request $request, string $id): JsonResponse
     {
         $session = PinSession::findOrFail($id);
+
+        if ($error = $this->validateTransition($session, 'confirmed')) {
+            return $error;
+        }
+
         $user = $request->user();
 
         $session->update([
@@ -127,6 +168,10 @@ class PinSessionController extends Controller
     {
         $session = PinSession::findOrFail($id);
 
+        if ($error = $this->validateTransition($session, 'approved')) {
+            return $error;
+        }
+
         $session->update([
             'status' => 'approved',
             'approved_at' => now(),
@@ -139,6 +184,10 @@ class PinSessionController extends Controller
     public function send(string $id): JsonResponse
     {
         $session = PinSession::findOrFail($id);
+
+        if ($error = $this->validateTransition($session, 'sent')) {
+            return $error;
+        }
 
         $this->savePinsToHistory($session);
 

--- a/routes/api.php
+++ b/routes/api.php
@@ -40,6 +40,9 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::get('/pin-sessions', [PinSessionController::class, 'index']);
     Route::get('/pin-sessions/{id}', [PinSessionController::class, 'show']);
 
+    // セッション確認提出（staff + admin）
+    Route::patch('/pin-sessions/{id}/confirm', [PinSessionController::class, 'confirm']);
+
     // admin専用
     Route::middleware('admin')->group(function () {
         // ユーザー管理
@@ -70,7 +73,6 @@ Route::middleware('auth:sanctum')->group(function () {
         Route::delete('/pin-sessions/{id}', [PinSessionController::class, 'destroy']);
         Route::patch('/pin-sessions/{id}/check', [PinSessionController::class, 'check']);
         Route::patch('/pin-sessions/{id}/publish', [PinSessionController::class, 'publish']);
-        Route::patch('/pin-sessions/{id}/confirm', [PinSessionController::class, 'confirm']);
         Route::patch('/pin-sessions/{id}/approve', [PinSessionController::class, 'approve']);
         Route::patch('/pin-sessions/{id}/send', [PinSessionController::class, 'send']);
     });


### PR DESCRIPTION
# 概要

confirmルートの権限をstaffに開放し、各ステータス遷移APIにバリデーションを追加した

## 実施した内容

- api.phpのconfirmルートをadminグループ外（auth:sanctum内）に移動
- PinSessionControllerにSTATUS_TRANSITIONS定数とvalidateTransitionメソッドを追加
- check / publish / confirm / approve / sendの各メソッドに遷移バリデーションを追加
- 不正な遷移時は422エラーとメッセージを返す

## 補足

- 遷移ルール: draft→checked→published→confirmed→approved→sent
- confirmはstaff+admin両方がアクセス可能、それ以外のステータス変更はadminのみ

## 関連issue

Closes #36