### PR TITLE
ci: テスト自動実行・自動デプロイ（GitHub Actions）

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,72 @@
+name: Backend CI/CD
+
+on:
+  push:
+    branches:
+      - "**"
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    services:
+      mysql:
+        image: mysql:8.4
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: pinposiplus_test
+        ports:
+          - 3306:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=3
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.4"
+          extensions: pdo_mysql, mbstring
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --prefer-dist
+
+      - name: Copy env
+        run: cp .env.example .env
+
+      - name: Generate key
+        run: php artisan key:generate
+
+      - name: Run tests
+        env:
+          DB_CONNECTION: sqlite
+          DB_DATABASE: ":memory:"
+        run: php artisan test --testsuite=Feature
+
+  deploy:
+    needs: test
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+
+    steps:
+      - name: Deploy to EC2
+        uses: appleboy/ssh-action@v1.0.0
+        with:
+          host: ${{ secrets.EC2_HOST }}
+          username: ec2-user
+          key: ${{ secrets.EC2_SSH_KEY }}
+          script: |
+            cd /home/ec2-user/pinposiplus/backend
+            git pull origin main
+            sudo docker-compose up -d --build
+            sudo docker-compose exec -T app php artisan migrate --force
+            sudo docker-compose exec -T app php artisan config:clear
+            sudo docker-compose exec -T app php artisan cache:clear


### PR DESCRIPTION
## 概要
push時にPHPUnitテストを自動実行し、mainマージ時にAWSへSSH自動デプロイするCI/CDパイプラインを構築。

## 実施した内容
- GitHub Actionsワークフロー作成
- 全ブランチpush時にFeatureテスト自動実行
- mainマージ時にEC2へSSHデプロイ（git pull → Docker再起動 → migrate）

## 関連issue
Closes #50