### PR TITLE
feat: デモリセットAPI追加

### DIFF
--- a/app/Http/Controllers/DemoResetController.php
+++ b/app/Http/Controllers/DemoResetController.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+
+class DemoResetController extends Controller
+{
+    public function reset(): JsonResponse
+    {
+        try {
+            // 全テーブルの外部キー制約を一時的に無効化
+            DB::statement('SET FOREIGN_KEY_CHECKS=0;');
+
+            DB::table('pins')->truncate();
+            DB::table('pin_histories')->truncate();
+            DB::table('pin_sessions')->truncate();
+            DB::table('damage_cells')->truncate();
+            DB::table('damage_cell_groups')->truncate();
+            DB::table('ban_cells')->truncate();
+            DB::table('ban_cell_groups')->truncate();
+            DB::table('rain_cells')->truncate();
+            DB::table('rain_cell_groups')->truncate();
+            DB::table('daily_schedules')->truncate();
+            DB::table('users')->truncate();
+
+            DB::statement('SET FOREIGN_KEY_CHECKS=1;');
+
+            // seeder再実行
+            Artisan::call('db:seed', ['--force' => true]);
+
+            return response()->json(['success' => true]);
+        } catch (\Exception $e) {
+            return response()->json(['success' => false, 'message' => $e->getMessage()], 500);
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -7,6 +7,7 @@ use App\Http\Controllers\BanCellGroupController;
 use App\Http\Controllers\DailyScheduleController;
 use App\Http\Controllers\DamageCellController;
 use App\Http\Controllers\DamageCellGroupController;
+use App\Http\Controllers\DemoResetController;
 use App\Http\Controllers\PinController;
 use App\Http\Controllers\PinHistoryController;
 use App\Http\Controllers\PinPositionMailController;
@@ -17,6 +18,7 @@ use App\Http\Controllers\UserController;
 use Illuminate\Support\Facades\Route;
 
 Route::post('/login', [AuthController::class, 'login']);
+Route::post('/demo-reset', [DemoResetController::class, 'reset']);
 
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);


### PR DESCRIPTION
## 概要
デモデータをリセットするAPIエンドポイントを追加

## 実施した内容
- DemoResetController作成（全テーブルtruncate → seeder再実行）
- POST /api/demo-reset ルート追加（認証不要）

## 関連issue
Closes #52